### PR TITLE
Fix specifying start bunny count

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ if (typeof PIXI === 'undefined')
 {
     const chooser = new VersionChooser('#chooser');
 
-    chooser.select = () => app.ready();
+    chooser.select = (startBunnyCount) => app.ready(startBunnyCount);
     chooser.init();
 }
 else


### PR DESCRIPTION
Currently, the app always starts at 100k, due to an error in the conversion from ESM not passing the parameter properly