### PR TITLE
fix bug where initial number of rabbits was not used

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ if (typeof PIXI === 'undefined')
 {
     const chooser = new VersionChooser('#chooser');
 
-    chooser.select = () => app.ready();
+    chooser.select = (numberOfRabbits) => app.ready(numberOfRabbits);
     chooser.init();
 }
 else


### PR DESCRIPTION
starting number was always 10000 because the value chosen in the chooser was not given to the app.ready function